### PR TITLE
Update cosine wikipedia link with correct text

### DIFF
--- a/lib/Type/Cool.pod
+++ b/lib/Type/Cool.pod
@@ -245,7 +245,7 @@ Usage:
     NUMERIC.cos
 
 Coerces the invocant (or in sub form, the argument) to L<Numeric|/type/Numeric>, interprets it as radians,
-returns its L<sine|https://en.wikipedia.org/wiki/Cosine>.
+returns its L<cosine|https://en.wikipedia.org/wiki/Cosine>.
 
     say 0.cos;                  # 1
     say pi.cos;                 # -1


### PR DESCRIPTION
Fixes https://github.com/perl6/doc/issues/143 . Change sine to cosine.